### PR TITLE
Fixed extra paragraph at start of paragraph chop

### DIFF
--- a/src/libs/Hacksaw.php
+++ b/src/libs/Hacksaw.php
@@ -85,7 +85,7 @@ class Hacksaw
 			$paragraphs = array_filter(explode("<p>", str_replace("</p>", "", $cleanContent)));
 			$paragraphs = array_slice($paragraphs, 0, $limit);
 			$paragraphsCount = count($paragraphs)-1;
-			$return = "<p>";
+			$return = "";
 			foreach ($paragraphs as $key => $paragraph)
 			{
 				$return .= "<p>" . $paragraph;


### PR DESCRIPTION
The chop method for paragraphs was creating an extra paragraph tag at the start of the output. This change removes the spurious paragraph tag.