### PR TITLE
Fixing settings assignment

### DIFF
--- a/src/services/TypographyService.php
+++ b/src/services/TypographyService.php
@@ -72,7 +72,8 @@ class TypographyService extends Component
 
 			if (is_array($settings)) {
 				foreach ($settings as $key => $value) {
-					$this->_typographySettings->{$key}($value);
+					$func = "set_{$key}";
+					$this->_typographySettings->$func($value);
 				}
 			}
 
@@ -93,7 +94,8 @@ class TypographyService extends Component
 
 		if (is_array($adhocSettings)) {
 			foreach ($adhocSettings as $key => $value) {
-				$settings->{$key}($value);
+				$func = "set_{$key}";
+				$settings->$func($value);
 			}
 		}
 


### PR DESCRIPTION
There was a bug in how this interacted with the underlying php-typography plugin, such that trying to set any settings would cause an error because the setter function wasn't found. I fixed it.