### PR TITLE
Accept Inflector ^2.0 as well as ^1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "voku/stringy": "^5.1||^6.0",
         "mofodojodino/profanity-filter": "^1.3",
         "davechild/textstatistics": "^1.0",
-        "icanboogie/inflector": "^1.4",
+        "icanboogie/inflector": "^1.4||^2.0",
         "erusev/parsedown-extra": "^0.8",
         "mundschenk-at/php-typography": "^6.0"
     },


### PR DESCRIPTION
This fixes (at least) the `pluralize` method to support PHP 7.4, which dropped support for the old syntax version 1.x of Inflector was using.

Closes #34